### PR TITLE
Função checkTeacher corrigida

### DIFF
--- a/src/endpoints/createTeacher.ts
+++ b/src/endpoints/createTeacher.ts
@@ -10,18 +10,17 @@ export default async function createTeacher(
   req: Request,
   res: Response
 ): Promise<void> {
-  let errorCode: number = 400;
   try {
     const { name, email, birth_date, specialties } = req.body;
 
     //validaçãodo do docente
-    checkTeacher(name, "'name'", errorCode);
-    checkTeacher(email, "'email'", errorCode);
-    checkTeacher(birth_date, "'birth_date'", errorCode);
+    checkTeacher(name, "'name'", res);
+    checkTeacher(email, "'email'", res);
+    checkTeacher(birth_date, "'birth_date'", res);
 
     //validação da especialidade
     if (!specialties || specialties.lenght === 0) {
-      errorCode = 422;
+      res.statusCode = 422;
       throw new Error("informe uma ou mais especialidades");
     }
     for (let item of specialties) {
@@ -42,7 +41,7 @@ export default async function createTeacher(
       email: email,
       //formatDate - função de formatação da data
       birth_date: formatDate(birth_date),
-      specialties: arraySpecialtys
+      specialties: arraySpecialtys,
     };
 
     //adicionando usuário no banco de dados
@@ -50,6 +49,6 @@ export default async function createTeacher(
 
     res.status(200).send(userTeacher);
   } catch (error) {
-    res.status(errorCode).send(error.sqlMessage || error.message );
+    res.send(error.sqlMessage || error.message);
   }
 }

--- a/src/util/checkTeacher.ts
+++ b/src/util/checkTeacher.ts
@@ -1,13 +1,15 @@
+import { Response } from "express";
+
 //validação do body do createTeacher
 
 export default function checkTeacher(
-  req: string,
-  props: string,
-  resStatusCode: number
-) {
+  req: string, 
+  props: string, res: Response) {
+  
   let Message = `(verifique o body) ausência da propriedade `;
+  
   if (!req || req === undefined) {
-    resStatusCode = 404;
+    res.statusCode = 422;
     throw new Error(Message + props);
   }
 }


### PR DESCRIPTION
O problema foi não ter passado o objeto response na função e tipado também no parâmetro da função checkTeacher.
Desse modo não foi preciso a declaração de uma nova variável de erro: let **erroCode** = 400 e nem a implementação res.**status(errorCode)**.send(error.sqlMessage || error.message);
permanecendo: res.send(error.sqlMessage || error.message);

Olhem as partes selecionadas:

![image](https://user-images.githubusercontent.com/71137294/105357181-34620c00-5bd3-11eb-8f51-5d450fd84d66.png)
